### PR TITLE
Exit fullscreen pressing esc

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -73,6 +73,8 @@ pub enum WindowEvent {
     Navigation(TopLevelBrowsingContextId, TraversalDirection),
     /// Sent when the user quits the application
     Quit,
+    /// Sent when the user exits from fullscreen mode
+    ExitFullScreen(TopLevelBrowsingContextId),
     /// Sent when a key input state changes
     Keyboard(KeyboardEvent),
     /// Sent when Ctr+R/Apple+R is called to reload the current page.
@@ -117,6 +119,7 @@ impl Debug for WindowEvent {
             WindowEvent::SelectBrowser(..) => write!(f, "SelectBrowser"),
             WindowEvent::ToggleWebRenderDebug(..) => write!(f, "ToggleWebRenderDebug"),
             WindowEvent::CaptureWebRender => write!(f, "CaptureWebRender"),
+            WindowEvent::ExitFullScreen(..) => write!(f, "ExitFullScreen"),
         }
     }
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -261,6 +261,8 @@ pub enum ConstellationControlMsg {
     Resize(PipelineId, WindowSizeData, WindowSizeType),
     /// Notifies script that window has been resized but to not take immediate action.
     ResizeInactive(PipelineId, WindowSizeData),
+    /// Window switched from fullscreen mode.
+    ExitFullScreen(PipelineId),
     /// Notifies the script that the document associated with this pipeline should 'unload'.
     UnloadDocument(PipelineId),
     /// Notifies the script that a pipeline should be closed.
@@ -386,6 +388,7 @@ impl fmt::Debug for ConstellationControlMsg {
             Reload(..) => "Reload",
             WebVREvents(..) => "WebVREvents",
             PaintMetric(..) => "PaintMetric",
+            ExitFullScreen(..) => "ExitFullScreen",
         };
         write!(formatter, "ConstellationControlMsg::{}", variant)
     }
@@ -776,6 +779,8 @@ pub enum ConstellationMsg {
     ForwardEvent(PipelineId, CompositorEvent),
     /// Requesting a change to the onscreen cursor.
     SetCursor(Cursor),
+    /// Request to exit from fullscreen mode
+    ExitFullScreen(Option<TopLevelBrowsingContextId>),
 }
 
 impl fmt::Debug for ConstellationMsg {
@@ -803,6 +808,7 @@ impl fmt::Debug for ConstellationMsg {
             SelectBrowser(..) => "SelectBrowser",
             ForwardEvent(..) => "ForwardEvent",
             SetCursor(..) => "SetCursor",
+            ExitFullScreen(..) => "ExitFullScreen",
         };
         write!(formatter, "ConstellationMsg::{}", variant)
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -397,6 +397,13 @@ where
                 self.compositor.maybe_start_shutting_down();
             },
 
+            WindowEvent::ExitFullScreen(top_level_browsing_context_id) => {
+                let msg = ConstellationMsg::ExitFullScreen(Some(top_level_browsing_context_id));
+                if let Err(e) = self.constellation_chan.send(msg) {
+                    warn!("Sending exit fullscreen to constellation failed ({:?}).", e);
+                }
+            },
+
             WindowEvent::Reload(top_level_browsing_context_id) => {
                 let msg = ConstellationMsg::Reload(top_level_browsing_context_id);
                 if let Err(e) = self.constellation_chan.send(msg) {

--- a/doc/22853_Support.patch
+++ b/doc/22853_Support.patch
@@ -1,0 +1,237 @@
+diff --git a/components/compositing/windowing.rs b/components/compositing/windowing.rs
+index 091eb661a5..ca314897d7 100644
+--- a/components/compositing/windowing.rs
++++ b/components/compositing/windowing.rs
+@@ -73,6 +73,8 @@ pub enum WindowEvent {
+     Navigation(TopLevelBrowsingContextId, TraversalDirection),
+     /// Sent when the user quits the application
+     Quit,
++    /// Sent when the user exits from fullscreen mode
++    ExitFullScreen(TopLevelBrowsingContextId),
+     /// Sent when a key input state changes
+     Keyboard(KeyboardEvent),
+     /// Sent when Ctr+R/Apple+R is called to reload the current page.
+@@ -117,6 +119,7 @@ impl Debug for WindowEvent {
+             WindowEvent::SelectBrowser(..) => write!(f, "SelectBrowser"),
+             WindowEvent::ToggleWebRenderDebug(..) => write!(f, "ToggleWebRenderDebug"),
+             WindowEvent::CaptureWebRender => write!(f, "CaptureWebRender"),
++            WindowEvent::ExitFullScreen(..) => write!(f, "ExitFullScreen"),
+         }
+     }
+ }
+diff --git a/components/constellation/constellation.rs b/components/constellation/constellation.rs
+index 2b6df7d456..11ef5e3957 100644
+--- a/components/constellation/constellation.rs
++++ b/components/constellation/constellation.rs
+@@ -1187,6 +1187,9 @@ where
+                 self.forward_event(destination_pipeline_id, event);
+             },
+             FromCompositorMsg::SetCursor(cursor) => self.handle_set_cursor_msg(cursor),
++            FromCompositorMsg::ExitFullScreen(top_level_browsing_context_id) => {
++                self.handle_exit_fullscreen_msg(top_level_browsing_context_id);
++            },
+         }
+     }
+ 
+@@ -3615,6 +3618,17 @@ where
+         self.window_size = new_size;
+     }
+ 
++    /// Called when the window exits from fullscreen mode
++    fn handle_exit_fullscreen_msg(
++        &mut self,
++        top_level_browsing_context_id: Option<TopLevelBrowsingContextId>,
++    ) {
++        if let Some(top_level_browsing_context_id) = top_level_browsing_context_id {
++            let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
++            self.switch_fullscreen_mode(browsing_context_id);
++        }
++    }
++
+     /// Handle updating actual viewport / zoom due to @viewport rules
+     fn handle_viewport_constrained_msg(
+         &mut self,
+@@ -3851,6 +3865,41 @@ where
+         }
+     }
+ 
++    // Handle switching from fullscreen mode
++    fn switch_fullscreen_mode(&mut self, browsing_context_id: BrowsingContextId) {
++        if let Some(browsing_context) = self.browsing_contexts.get_mut(&browsing_context_id) {
++            let pipeline_id = browsing_context.pipeline_id;
++            let pipeline = match self.pipelines.get(&pipeline_id) {
++                None => {
++                    return warn!(
++                        "Pipeline {:?} switched from fullscreen mode after closing.",
++                        pipeline_id
++                    )
++                },
++                Some(pipeline) => pipeline,
++            };
++            let _ = pipeline
++                .event_loop
++                .send(ConstellationControlMsg::ExitFullScreen(pipeline.id));
++        }
++        // Send exit fullscreen message to any pending pipelines that aren't loaded yet
++        for change in &self.pending_changes {
++            let pipeline_id = change.new_pipeline_id;
++            let pipeline = match self.pipelines.get(&pipeline_id) {
++                None => {
++                    warn!("Pending pipelone {:?} is closed", pipeline_id);
++                    continue;
++                },
++                Some(pipeline) => pipeline,
++            };
++            if pipeline.browsing_context_id == browsing_context_id {
++                let _ = pipeline
++                    .event_loop
++                    .send(ConstellationControlMsg::ExitFullScreen(pipeline_id));
++            }
++        }
++    }
++
+     // Close a browsing context (and all children)
+     fn close_browsing_context(
+         &mut self,
+diff --git a/components/script/script_thread.rs b/components/script/script_thread.rs
+index 4076a56f9c..014e608542 100644
+--- a/components/script/script_thread.rs
++++ b/components/script/script_thread.rs
+@@ -1252,6 +1252,10 @@ impl ScriptThread {
+                         Some(index) => sequential[index] = event,
+                     }
+                 },
++                FromConstellation(ConstellationControlMsg::ExitFullScreen(id)) => self
++                    .profile_event(ScriptThreadEventCategory::ExitFullscreen, Some(id), || {
++                        self.handle_exit_fullscreen(id);
++                    }),
+                 _ => {
+                     sequential.push(event);
+                 },
+@@ -1448,6 +1452,7 @@ impl ScriptThread {
+                     Reload(id, ..) => Some(id),
+                     WebVREvents(id, ..) => Some(id),
+                     PaintMetric(..) => None,
++                    ExitFullScreen(id, ..) => Some(id),
+                 }
+             },
+             MixedMessage::FromDevtools(_) => None,
+@@ -1676,6 +1681,7 @@ impl ScriptThread {
+             msg @ ConstellationControlMsg::Viewport(..) |
+             msg @ ConstellationControlMsg::SetScrollState(..) |
+             msg @ ConstellationControlMsg::Resize(..) |
++            msg @ ConstellationControlMsg::ExitFullScreen(..) |
+             msg @ ConstellationControlMsg::ExitScriptThread => {
+                 panic!("should have handled {:?} already", msg)
+             },
+@@ -1888,6 +1894,18 @@ impl ScriptThread {
+         warn!("resize sent to nonexistent pipeline");
+     }
+ 
++    fn handle_exit_fullscreen(&self, id: PipelineId) {
++        let document = self.documents.borrow().find_document(id);
++        if let Some(document) = document {
++            let _ac = JSAutoCompartment::new(
++                document.global().get_cx(),
++                document.reflector().get_jsobject().get(),
++            );
++            document.exit_fullscreen();
++            return;
++        }
++    }
++
+     fn handle_viewport(&self, id: PipelineId, rect: Rect<f32>) {
+         let document = self.documents.borrow().find_document(id);
+         if let Some(document) = document {
+diff --git a/components/script_traits/lib.rs b/components/script_traits/lib.rs
+index e2bc5c4d1e..b273f5d9bc 100644
+--- a/components/script_traits/lib.rs
++++ b/components/script_traits/lib.rs
+@@ -261,6 +261,8 @@ pub enum ConstellationControlMsg {
+     Resize(PipelineId, WindowSizeData, WindowSizeType),
+     /// Notifies script that window has been resized but to not take immediate action.
+     ResizeInactive(PipelineId, WindowSizeData),
++    /// Window switched from fullscreen mode.
++    ExitFullScreen(PipelineId),
+     /// Notifies the script that the document associated with this pipeline should 'unload'.
+     UnloadDocument(PipelineId),
+     /// Notifies the script that a pipeline should be closed.
+@@ -386,6 +388,7 @@ impl fmt::Debug for ConstellationControlMsg {
+             Reload(..) => "Reload",
+             WebVREvents(..) => "WebVREvents",
+             PaintMetric(..) => "PaintMetric",
++            ExitFullScreen(..) => "ExitFullScreen",
+         };
+         write!(formatter, "ConstellationControlMsg::{}", variant)
+     }
+@@ -776,6 +779,8 @@ pub enum ConstellationMsg {
+     ForwardEvent(PipelineId, CompositorEvent),
+     /// Requesting a change to the onscreen cursor.
+     SetCursor(Cursor),
++    /// Request to exit from fullscreen mode
++    ExitFullScreen(Option<TopLevelBrowsingContextId>),
+ }
+ 
+ impl fmt::Debug for ConstellationMsg {
+@@ -803,6 +808,7 @@ impl fmt::Debug for ConstellationMsg {
+             SelectBrowser(..) => "SelectBrowser",
+             ForwardEvent(..) => "ForwardEvent",
+             SetCursor(..) => "SetCursor",
++            ExitFullScreen(..) => "ExitFullScreen",
+         };
+         write!(formatter, "ConstellationMsg::{}", variant)
+     }
+diff --git a/components/servo/lib.rs b/components/servo/lib.rs
+index 95a02c25af..6bf5ec6c0a 100644
+--- a/components/servo/lib.rs
++++ b/components/servo/lib.rs
+@@ -397,6 +397,13 @@ where
+                 self.compositor.maybe_start_shutting_down();
+             },
+ 
++            WindowEvent::ExitFullScreen(top_level_browsing_context_id) => {
++                let msg = ConstellationMsg::ExitFullScreen(Some(top_level_browsing_context_id));
++                if let Err(e) = self.constellation_chan.send(msg) {
++                    warn!("Sending exit fullscreen to constellation failed ({:?}).", e);
++                }
++            },
++
+             WindowEvent::Reload(top_level_browsing_context_id) => {
+                 let msg = ConstellationMsg::Reload(top_level_browsing_context_id);
+                 if let Err(e) = self.constellation_chan.send(msg) {
+diff --git a/ports/servo/browser.rs b/ports/servo/browser.rs
+index 7841730540..0581a43351 100644
+--- a/ports/servo/browser.rs
++++ b/ports/servo/browser.rs
+@@ -143,7 +143,15 @@ impl Browser {
+                 }
+             })
+             .shortcut(Modifiers::empty(), Key::Escape, || {
+-                self.event_queue.push(WindowEvent::Quit);
++                let state = self.window.get_fullscreen();
++                if state {
++                    if let Some(id) = self.browser_id {
++                        let event = WindowEvent::ExitFullScreen(id);
++                        self.event_queue.push(event);
++                    }
++                } else {
++                    self.event_queue.push(WindowEvent::Quit);
++                }
+             })
+             .otherwise(|| self.platform_handle_key(key_event));
+     }
+diff --git a/ports/servo/glutin_app/window.rs b/ports/servo/glutin_app/window.rs
+index 26e0d163fd..8592a92cde 100644
+--- a/ports/servo/glutin_app/window.rs
++++ b/ports/servo/glutin_app/window.rs
+@@ -331,6 +331,10 @@ impl Window {
+         self.fullscreen.set(state);
+     }
+ 
++    pub fn get_fullscreen(&self) -> bool {
++        return self.fullscreen.get();
++    }
++
+     fn is_animating(&self) -> bool {
+         self.animation_state.get() == AnimationState::Animating && !self.suspended.get()
+     }

--- a/ports/servo/browser.rs
+++ b/ports/servo/browser.rs
@@ -143,7 +143,15 @@ impl Browser {
                 }
             })
             .shortcut(Modifiers::empty(), Key::Escape, || {
-                self.event_queue.push(WindowEvent::Quit);
+                let state = self.window.get_fullscreen();
+                if state {
+                    if let Some(id) = self.browser_id {
+                        let event = WindowEvent::ExitFullScreen(id);
+                        self.event_queue.push(event);
+                    }
+                } else {
+                    self.event_queue.push(WindowEvent::Quit);
+                }
             })
             .otherwise(|| self.platform_handle_key(key_event));
     }

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -331,6 +331,10 @@ impl Window {
         self.fullscreen.set(state);
     }
 
+    pub fn get_fullscreen(&self) -> bool {
+        return self.fullscreen.get();
+    }
+
     fn is_animating(&self) -> bool {
         self.animation_state.get() == AnimationState::Animating && !self.suspended.get()
     }


### PR DESCRIPTION
Added implementation of exiting from fullscreen mode by pressing 'ESC' button. When the 'Escape' button is pressed, it sends a message to the constellation to exit fullscreen (which will get passed to the appropriate script thread and invoke document.exit_fullscreen().
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22853